### PR TITLE
fix(grpc): Fix error "proto3 disallow 'optional' label" 

### DIFF
--- a/kong/tools/grpc.lua
+++ b/kong/tools/grpc.lua
@@ -77,6 +77,7 @@ function _M.new()
     protoc_instance:addpath(v)
   end
   protoc_instance.include_imports = true
+  protoc_instance.proto3_optional = true
 
   return setmetatable({
     protoc_instance = protoc_instance,

--- a/spec/fixtures/grpc/targetservice.proto
+++ b/spec/fixtures/grpc/targetservice.proto
@@ -56,7 +56,7 @@ service Bouncer {
 
 message HelloRequest {
   string greeting = 1;
-  bool boolean_test = 2;
+  optional bool boolean_test = 2;
 }
 
 message HelloResponse {


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Fix [Issue 14421](https://github.com/Kong/kong/issues/14421)
grpc-gateway fails to load proto file with message "proto3 disallow 'optional' label"

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[14421]_(https://github.com/Kong/kong/issues/14421)
